### PR TITLE
メッセージ一覧よりShow/Edit/Destroyリンクを消す

### DIFF
--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -6,9 +6,6 @@
   <tr>
     <td><%= message.created_at.localtime.strftime('%H:%M') %></td>
     <td><%= message.content %></td>
-    <td><%= link_to 'Show', message %></td>
-    <td><%= link_to 'Edit', edit_message_path(message) %></td>
-    <td><%= link_to 'Destroy', message, method: :delete, data: { confirm: 'Are you sure?' } %></td>
   </tr>
 <% end %>
 </table>


### PR DESCRIPTION
最初の段階で必須というわけではないので消す。
画面上からとりあえず消えればいい。アクションとかは残しておく
