### PR TITLE
ログインフォームのModal化

### DIFF
--- a/app/views/authentication/index.html.erb
+++ b/app/views/authentication/index.html.erb
@@ -1,4 +1,12 @@
-<%= form_tag({:controller => 'authentication', :action => 'login'}, {class: 'form-inline'}) do %>
-  <%= text_field_tag 'user_name'%>
-  <%= submit_tag 'Login', class: 'btn' %>
-<% end %>
+<a href="#myModal" role="button" class="btn btn-primary btn-large" data-toggle="modal">サインイン</a>
+<div class="modal hide fade" id="myModal">
+  <div class="modal-header">
+    <h3>サインイン</h3>
+  </div>
+  <div class="modal-body">
+    <%= form_tag({:controller => 'authentication', :action => 'login'}, {class: 'form-inline'}) do %>
+    <%= text_field_tag 'user_name'%>
+    <%= submit_tag 'Login', class: 'btn' %>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
```
09:33 (toshi) Modalでログインフォーム出すとスタイリッシュじゃない？
09:34 (toshi) トップ画面にはSign inボタンだけだしておく
09:34 (toshi) で、
09:34 (toshi) Modalでログインフォーム出してログイン
09:35 (toshi) Issue化しよう
09:35 (toshi) http://twitter.github.com/bootstrap/javascript.html#modals
09:35 (toshi) これ
09:35 (toshi) Launch demo modalボタン押すとウィンドウっぽいのが出てくる
09:36 (toshi) 組み込み方は、単に
09:36 (toshi) <div class="modal"
09:36 (toshi) とボタン
09:37 (toshi) <a href="#myModal" role="button" class="btn" data-toggle="modal">Launch demo modal</a>
09:37 (toshi) の、data-toggle="modal"を付けて、id(#myModal)にinner Link
09:37 (toshi) で完成
```
