### PR TITLE
Pusher APIのProxy越え

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -51,6 +51,7 @@ class MessagesController < ApplicationController
     Pusher.app_id = '27608'
     Pusher.key = '3addd561c2cd0d1a49ed'
     Pusher.secret = ENV['pusher_secret']
+    Pusher.http_proxy = ENV['http_proxy'] if ENV['http_proxy'].present?
 
     respond_to do |format|
       if @message[:content].blank? or @message.save


### PR DESCRIPTION
Pusherで利用するWebSocketサーバ自体はプロキシ越えが可能だが、tiramisuを配置するサーバがProxy配下内だと、Pusher gemがproxy対応していないため、動作出来ない。

pusher gemをproxy対応する。うまく対応出来るようだったらgem側にPull-Requestしてみる
### pusher-gem

pusher-gem側にも修正を加えた：
[toshi3221/pusher-gem at proxy](https://github.com/toshi3221/pusher-gem/tree/proxy)

proxyブランチを rake build してgemを生成するか、Downloadsに[gemファイルを添付した](https://github.com/downloads/web-k/tiramisu/pusher-0.9.4.gem)のでインストールしてください

> sudo gem install --force --local pusher-0.9.4.gem --no-ri --no-rdoc
### 参考リンク
- [pusher gem](https://github.com/pusher/pusher-gem)
- [net/http るりま](http://doc.ruby-lang.org/ja/1.9.3/library/net=2fhttp.html)
- [em-http-request Proxy](https://github.com/igrigorik/em-http-request/wiki/Proxy)
