### PR TITLE
XSS防止

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
+  include ERB::Util
 
   def login?
     session[:user_name].present?

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -55,7 +55,7 @@ class MessagesController < ApplicationController
 
     respond_to do |format|
       if @message[:content].blank? or @message.save
-        Pusher['trms-channel'].trigger('message_added', {:message => @message, :time => @message.created_at.localtime.strftime('%H:%M')})
+        Pusher['trms-channel'].trigger('message_added', {message: {user_name: h(@message.user_name), content: h(@message.content)}, time: @message.created_at.localtime.strftime('%H:%M')})
         format.html { redirect_to root_path }
         format.json { render json: @message, status: :created, location: @message }
       else


### PR DESCRIPTION
Viewで作成したHTMLは自動的にXSS対策がなされており、html_escapeされています。
Pusherを利用して@messageをそのまま投げていますが、その状態だとhtml_escapeされていないのでWebSocketで更新されている時はXSSが防げない状態になっています
### やること
- Pusherに渡す時にはメッセージ、名前をhtml_escapeしましょう。
  - @messegeオブジェクトを生渡しするのはやめ、渡したいパラメータだけ、正しくHash化して値をきちんと設定してください。その際にエスケープします
  - ERB::Util.html_escape というメソッドを使えば多分エスケープ出来ます。
