### PR TITLE
タブレット操作時のスクロール禁止をdocument全体からItemだけに限定する

### DIFF
--- a/app/assets/javascripts/main.js.erb
+++ b/app/assets/javascripts/main.js.erb
@@ -68,7 +68,7 @@ $(function(){
         }
     });
     /* 縦スクロール禁止 */
-    $(document).bind("touchmove", function() {
+    $(".draggable").bind("touchmove", function() {
       event.preventDefault();
     });
   }

--- a/app/assets/stylesheets/messages.css.scss
+++ b/app/assets/stylesheets/messages.css.scss
@@ -34,4 +34,5 @@
 }
 .span9.go {
   min-width: 700px;
+  margin-bottom: 12px;
 }


### PR DESCRIPTION
いまは$(document).bind("touchmove", ... になってるので、全体のtouchmoveイベントを拾ってスクロールを禁止している。

これの制限を緩めて、Item(.draggable)だけがスクロール禁止にする。

Itemをドラッグするときはスクロールしないが、その他はスクロールやピンチ(拡大縮小)ができるようになるため。
