### PR TITLE
bootstrapアップグレード(v2→v3)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,10 @@ ruby '2.6.3'
 gem 'rails'
 
 gem 'listen'
-gem 'sass-rails'
 
 gem "font-awesome-rails"
-gem "bootstrap-sass", '2.3.2'
+gem "bootstrap-sass", '>=2.3.2'
+gem 'sassc-rails', '>= 2.1.0'
 gem "rails_autolink"
 gem 'bootsnap', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
     multi_json (1.13.1)
     multi_test (0.1.2)
     nio4r (2.4.0)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)
     parser (2.6.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,11 +46,14 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
+    autoprefixer-rails (9.6.1)
+      execjs
     backports (3.15.0)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
-    bootstrap-sass (2.3.2.0)
-      sass (~> 3.2)
+    bootstrap-sass (3.4.1)
+      autoprefixer-rails (>= 5.2.1)
+      sassc (>= 2.0.0)
     brakeman (4.5.1)
     builder (3.2.3)
     capybara (3.26.0)
@@ -214,17 +217,14 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sassc (2.1.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -256,7 +256,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  bootstrap-sass (= 2.3.2)
+  bootstrap-sass (>= 2.3.2)
   brakeman
   capybara
   cucumber
@@ -275,7 +275,7 @@ DEPENDENCIES
   rspec-activemodel-mocks
   rspec-rails
   rubocop
-  sass-rails
+  sassc-rails (>= 2.1.0)
   sqlite3
   uglifier
   webpacker (>= 4)

--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -9,18 +9,13 @@
  * compiled file, but it's generally better to create a new file per style scope.
  *
  */
+@import "bootstrap-sprockets";
 @import "bootstrap";
 
 @textColor: #999;
 
 body {
        padding-top: 56px;
-}
-.navbar .brand {
-  padding: 0 20px;
-  position: relative;
-  top: 6px;
-  left: -1px;
 }
 
 // Set the Font Awesome (Font Awesome is default. You can disable by commenting below lines)
@@ -58,24 +53,41 @@ header.subhead {
     margin-right: -20px;
   }
 }
-.navbar .nav.logout {
-  margin-top: 8px;
-  .btn {
-    margin-top: -2px;
-    margin-left: 4px;
+.navbar {
+  .navbar-brand {
+    padding: 0;
+    position: relative;
+    top: 10px;
+    left: -1px;
+  }
+  .navbar-nav {
+    &.logout {
+      margin-top: 12px;
+    }
+    .btn {
+      margin-top: -2px;
+      margin-left: 4px;
+      &.sign-in {
+        margin-top: 10px;
+      }
+    }
+  }
+  & + .container {
+    margin-top: 10px;
   }
 }
 #message_content {
   width: 98%;
 }
-.span3 {
-  .new_message {
-    margin-right: 8px;
-   }
+.col-md-3, .col-md-9 {
+  form {
+    margin-bottom: 6px;
+  }
   .messages {
     height: 300px;
     width: 100%;
     overflow: auto;
+    padding-inline-start: 0;
   }
 }
 #main .error {
@@ -92,4 +104,9 @@ form.edit_channel {
     background-size: contain;
     opacity: 0.5;
   }
+}
+
+#new_channel {
+  margin-top: 6px;
+  margin-bottom: 16px;
 }

--- a/app/assets/stylesheets/messages.css.scss
+++ b/app/assets/stylesheets/messages.css.scss
@@ -32,10 +32,17 @@
     color: gray;
   }
 }
-.span9.go {
-  min-width: 700px;
-  margin-bottom: 12px;
+.go {
+  &.col-md-9 {
+    min-width: 700px;
+    margin-bottom: 12px;
+    padding-right: 0;
+  }
+  &.col-md-3{
+    padding-left: 0;
+  }
 }
+
 .active {
   z-index: 100;
 }

--- a/app/javascript/packs/main.js.erb
+++ b/app/javascript/packs/main.js.erb
@@ -174,7 +174,7 @@ function set_label(id, name, top, left) {
       });
     } else {
       $(".label").remove();
-      $set_label_item.after("<div class='label'>" + name + "</div>");
+      $set_label_item.after("<div class='label label-default'>" + name + "</div>");
       $(".label").css(set_position);
     }
 }
@@ -235,7 +235,7 @@ function initialize_table_upside() {
     if (tu) {
       if(tu === 'down') { setTimeout(function(){toggle_table_upside();}, 300); }
     }
-    var $upside_button = $('<button class="btn btn-small" id="table_upside">テーブル回転</button>');
+    var $upside_button = $('<button class="btn btn-default btn-sm" id="table_upside">テーブル回転</button>');
     $('p.logout').append($upside_button);
     $upside_button.click(toggle_table_upside);
   }
@@ -318,7 +318,7 @@ function initialize_sound_onoff() {
   } else {
     sound_onoff_str = "sound off ";
   }
-  $onoff_button = $('<button class="btn btn-small" id="sound_onoff" onclick="change_soundonoff(this)"> ' + sound_onoff_str + '</button>');
+  $onoff_button = $('<button class="btn btn-default btn-sm" id="sound_onoff" onclick="change_soundonoff(this)"> ' + sound_onoff_str + '</button>');
   $('p.logout').append($onoff_button);
 }
 function change_soundonoff(item) {

--- a/app/javascript/packs/webrtc.js.erb
+++ b/app/javascript/packs/webrtc.js.erb
@@ -45,8 +45,8 @@ $(function() {
         $('#'+id).parent().hasClass("audio") ? $('#'+id).parent().remove() : $('#'+id).remove();
       });
 
-      var $audio_chat_button = $('<input type="button" class="btn btn-small" value="音声チャット" id="audio_chat_on" />');
-      var $video_chat_button = $('<input type="button" class="btn btn-small" value="ビデオチャット" id="video_chat_on" />');
+      var $audio_chat_button = $('<input type="button" class="btn btn-default btn-sm" value="音声チャット" id="audio_chat_on" />');
+      var $video_chat_button = $('<input type="button" class="btn btn-default btn-sm" value="ビデオチャット" id="video_chat_on" />');
       $('p.logout').append($audio_chat_button).append($video_chat_button);
 
       var start_chat = function (is_video) {

--- a/app/views/authentication/index.html.erb
+++ b/app/views/authentication/index.html.erb
@@ -1,28 +1,31 @@
-<div class="modal hide fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-  <div class="modal-header">
-    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">x</button>
-    <h3>サインイン</h3>
-  </div>
-  <div class="modal-body">
-    <%= form_tag({controller: 'authentication', action: 'login'}, {class: 'form-inline'}) do %>
-    <%= hidden_field_tag :callback, @callback_url %>
-    <%= text_field_tag 'user_name'%>
-    <%= submit_tag 'Login', class: 'btn' %>
-    <% end %>
-  </div>
-</div>
-
-<div class="row-fluid">
-  <div class="span4 hero-unit">
+<div class="row">
+  <div class="col-md-4">
     <h2>Tiramisuとは</h2>
     <p>Tiramisu(ティラミス)とはWebチャットシステムです。名前を入力してサインインすればブラウザ上でチャットを行うことができます。</p>
   </div>
-  <div class="span4 hero-unit">
+  <div class="col-md-4">
     <h2>特徴</h2>
     <p>WebSocketを利用したリアルタイムチャットが可能。Web上でIRCと同じ様な操作感を味わえます。また、ログインしていなくても過去のログが保存されているので遡ってメッセージを参照出来ます。</p>
   </div>
-  <div class="span4 hero-unit">
+  <div class="col-md-4">
     <h2>Let's enjoy!</h2>
     <p>Tiramisuでチャットを楽しんでください。TiramisuはMITライセンスのオープンソースです。<a href="https://github.com/web-k/tiramisu" target="_blank">Github</a>にて公開しています。意見・要望・Pull-Requestはtiramisuプロジェクトまでお寄せください。</p>
   </div>
+</div>
+
+<div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">x</button>
+        <h3 class="modal-title">サインイン</h3>
+      </div>
+      <div class="modal-body">
+        <%= form_tag({controller: 'authentication', action: 'login'}, {class: 'form-inline'}) do %>
+        <%= hidden_field_tag :callback, @callback_url %>
+        <%= text_field_tag 'user_name'%>
+        <%= submit_tag 'Login', class: 'btn btn-default' %>
+        <% end %>
+      </div>
+    </div>
 </div>

--- a/app/views/channels/index.html.erb
+++ b/app/views/channels/index.html.erb
@@ -9,7 +9,7 @@
     <%= select_tag :table, options_for_select(table_options, 'none') %>
   </span>
   <span class="actions">
-    <%= f.submit "チャンネルを作成", :class => 'btn' %>
+    <%= f.submit "チャンネルを作成", :class => 'btn btn-default btn-sm' %>
   </span>
 <% end %>
 <table class="channels table table-bordered table-striped table-condensed">

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 <% end %>
 <div class="row">
-  <div class="span9<%= @table.present? && @table.name.include?('Go') ? ' go' : '' %><%= @table.present? && @table.name=='VideoChat' ? ' video_chat' : '' %>">
+  <div class="col-lg-8 col-md-9<%= @table.present? && @table.name.include?('Go') ? ' go' : '' %><%= @table.present? && @table.name=='VideoChat' ? ' video_chat' : '' %>">
     <% if @table.present? && @table.name.include?('Go') %>
     <div id="table_area">
       <style TYPE="text/css">
@@ -18,7 +18,7 @@
       <% @table.items.each do |item| %>
         <img class="draggable" style="position: absolute; top: <%= item.position_y %>px; left: <%= item.position_x %>px;" src="<%= asset_path item.kind+'.gif' %>" data-item-id="<%= item.id %>">
         <% if @latest_moving_item.present? and @latest_moving_item.id == item.id %>
-        <div class="label" style="top: <%= item.position_y %>px; left: <%= item.position_x + 30 %>px;"><%= item.latest_moving_user_name %></div>
+        <div class="label label-default" style="top: <%= item.position_y %>px; left: <%= item.position_x + 30 %>px;"><%= item.latest_moving_user_name %></div>
         <% end %>
       <% end %>
       <%= audio_tag "spo_ge_igo_utu01.mp3", id: "go_sound", preload: "auto" %>
@@ -37,7 +37,7 @@
     <%= render 'messages' %>
     <% end %>
   </div>
-  <div class="span3">
+  <div class="col-lg-4 col-md-3">
     <% if @table.present? %>
     <%= render 'messages' %>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,10 +22,10 @@
   </head>
   <body>
 
-    <div class="navbar navbar-fixed-top">
+    <div class="navbar navbar-default navbar-fixed-top">
       <div class="navbar-inner">
         <div class="container">
-          <div class="brand">
+          <div class="navbar-brand">
             <%= link_to image_tag('tiramisu_logo.png', alt: 'Tiramisu', title: 'Tiramisu'), root_path %>
             <% if !@channel.nil? && @channel.id.present? %><%= form_for(@channel, :url => {:action => 'update'}, :method => :put) do |f| %>
               <% if @channel.errors.any? %>
@@ -43,9 +43,9 @@
               <div id="channel_name_edit" style="display:none;"><%= f.text_field :name %></div>
             <% end %><% end %>
           </div>
-          <p class="nav pull-right logout">
+          <p class="navbar-nav pull-right logout">
             こんにちは <span id="my_name"><%= session[:user_name]%></span> さん
-            <%= link_to 'ログアウト', {:controller => 'authentication', :action => 'logout'}, {:class => 'btn btn-small'} %>
+            <%= link_to 'ログアウト', {:controller => 'authentication', :action => 'logout'}, {:class => 'btn btn-default btn-sm'} %>
           </p>
         </div>
       </div>

--- a/app/views/layouts/top.html.erb
+++ b/app/views/layouts/top.html.erb
@@ -20,13 +20,13 @@
   </head>
   <body>
 
-    <div class="navbar navbar-fixed-top">
+    <div class="navbar navbar-default navbar-fixed-top">
       <div class="navbar-inner">
         <div class="container">
-          <div class="brand"><%= image_tag 'tiramisu_logo.png', alt: 'Tiramisu', title: 'Tiramisu' %></div>
-          <div class="nav pull-right">
+          <div class="navbar-brand"><%= image_tag 'tiramisu_logo.png', alt: 'Tiramisu', title: 'Tiramisu' %></div>
+          <div class="navbar-nav pull-right">
             <p>
-              <a href="#myModal" role="button" class="btn sign-in" data-toggle="modal">サインイン</a>
+              <a href="#myModal" role="button" class="btn btn-default btn-sm sign-in" data-toggle="modal">サインイン</a>
             </p>
           </div>
         </div>
@@ -40,7 +40,7 @@
     <div class="container">
       <div class="content">
         <div class="row">
-           <div class="span12">
+           <div class="col-md-12">
               <%= yield %>
             </div>
         </div><!--/row-->


### PR DESCRIPTION
## やったこと

* `bootstrap-sass`のアップグレード(v2→v3)
  * クラス名、スタイルがガタガタに崩れた奴を参考リンクで移行手順見ながらせっせと直す
  * このgemはv3迄で、bootstrap4は別gemになる
* ついでにセキュリティアラート出てた`nokogiri`のアップデート

## 参考リンク

* [twbs/bootstrap-sass: Official Sass port of Bootstrap 2 and 3.](https://github.com/twbs/bootstrap-sass)
* [Migrating to v3.x · Bootstrap](https://getbootstrap.com/docs/3.4/migration/)